### PR TITLE
fix position going outside sample boundaries on ping-pong looped samples

### DIFF
--- a/src/state_sample.rs
+++ b/src/state_sample.rs
@@ -134,7 +134,7 @@ impl StateSample {
                     /* sanity self.cking */
                     if self.position as usize >= self.sample.len() {
                         self.ping = false;
-                        self.position -= self.sample.len() as f32 - 1.0;
+                        self.position = self.sample.len() as f32 - 1.0;
                     }
 
                     let seek = if b >= loop_end { a } else { b };


### PR DESCRIPTION
sup, happy new year.

  On certain conditions, position can move way outside sample boundaries when ping-pong looping is applied.
  This then leads to a panic caused by trying to access an out-of-bounds position when calling `Sample::at`.

  The sequence starts when doing the following once `position` exceeds sanple length:

  ```rust
  // src/state_sample.rs
  if self.position as usize >= self.sample.len() {
     self.ping = false;
     self.position -= self.sample.len() as f32 - 1.0;
  }
  ```

  This is problematic because it can put position way before way before `loop_start`.
  In my case `loop_end ~= sample.len()`, which now makes `position` < `1.0`.

  Because `ping` is now `false`, the other branch gets executed:

  ```rust
  // src/state_sample.rs
  if self.position as u32 <= self.sample.loop_start {
     self.ping = true;
     self.position = (self.sample.loop_start << 1) as f32 - self.position;
  }
  ```

  This part assumes `position` is pretty near `loop_start`.
  Because now position is roughly `1.0`, position now gets the value `loop_start * 2 - 1`.
  No other safety checks are applied, so `position` can end up being much bigger than `sample.len()`.
  In my case, after `position` receives this value, `Sample::at` get called and the panic is triggered.

  I have successfully tested this panic using [CoreTex - Home](https://modarchive.org/index.php?request=view_by_moduleid&query=159594) while runing `rodio_player`.
  The following command was used: `RUST_BACKTRACE=1 cargo run --features demo --example rodio_player -- -f coretex_-_home.xm -p 48 -d`
  Channels 7 and 8 keep sample 7 alive past pattern 48, before pattern 49 is finished a panic will occurr.

  I've found that applying the following change can fix the issue.

  ```rust
  // src/state_sample.rs
  if self.position as usize >= self.sample.len() {
     self.ping = false;
     self.position = self.sample.len() as f32 - 1.0;
  }
  ```

  This simply puts position at the end. Substracting `1.0` from it is required because how tricky `f32` to/from `u32` comversion behaves.
  Omitting it can still put `position` after `sample.len()` after casting is applied.
  It also has more sense because we're trying to put position in a place that allows playing the sample in reverse.
